### PR TITLE
Fixes for building on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.69])
+AC_PREREQ([2.72])
 AC_INIT([dbench],[5.0],[ronniesahlberg@gmail.com])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])
@@ -38,7 +38,59 @@ AC_SEARCH_LIBS(getxattr, [attr])
 AC_SEARCH_LIBS(socket, [socket])
 AC_SEARCH_LIBS(gethostbyname, [nsl])
 
-AC_CHECK_FUNCS(getxattr lgetxattr fgetxattr listxattr llistxattr)
+AC_MSG_CHECKING(for DIRECT open flag)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _GNU_SOURCE
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+]], [[ int oflag = O_DIRECT;
+]])],[
+    AC_DEFINE(HAVE_O_DIRECT,1,[ Define if DIRECT open flag is supported])
+    AC_MSG_RESULT(yes)
+  ],[AC_MSG_RESULT(no)
+])
+
+AC_CHECK_HEADERS([sys/xattr.h fcntl.h])
+AC_MSG_CHECKING([for getxattr with position and flags support])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/xattr.h>
+     #include <fcntl.h>
+     ]], [[
+            char buf[1];
+            ssize_t ret = getxattr("path", "user.test", buf, sizeof(buf), 0, 0);
+            return 0;
+     ]])],[AC_DEFINE(HAVE_GETXATTR_POS_FLAGS, 1, [Define if fgetxattr supports position and flags])
+    AC_MSG_RESULT([yes])],[AC_MSG_RESULT(no)
+])
+
+AC_CHECK_HEADERS([sys/xattr.h fcntl.h])
+AC_MSG_CHECKING([for fgetxattr with position and flags support])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/xattr.h>
+     #include <fcntl.h>
+     ]], [[
+            int fd = -1;
+            char buf[1];
+            ssize_t ret = fgetxattr(fd, "user.test", buf, sizeof(buf), 0, 0);
+            return 0;
+     ]])],[AC_DEFINE(HAVE_FGETXATTR_POS_FLAGS, 1, [Define if fgetxattr supports position and flags])
+    AC_MSG_RESULT([yes])],[AC_MSG_RESULT(no)
+])
+
+AC_CHECK_HEADERS([sys/xattr.h fcntl.h])
+AC_MSG_CHECKING([for setxattr with position and flags support])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/xattr.h>
+     #include <fcntl.h>
+     ]], [[
+            int fd = -1;
+            char buf[1];
+            ssize_t ret = fsetxattr(fd, "user.test", buf, sizeof(buf), 0, 0);
+            return 0;
+     ]])],[AC_DEFINE(HAVE_FSETXATTR_POS, 1, [Define if setxattr supports position and flags])
+    AC_MSG_RESULT([yes])],[AC_MSG_RESULT(no)
+])
+
+AC_CHECK_FUNCS(getxattr lgetxattr fgetxattr listxattr llistxattr fdatasync)
+AC_CHECK_DECLS([fdatasync])
 AC_CHECK_FUNCS(flistxattr removexattr lremovexattr fremovexattr)
 AC_CHECK_FUNCS(setxattr lsetxattr fsetxattr)
 # Check if we have attr_get
@@ -124,23 +176,24 @@ ac_save_LIBS="$LIBS"
 CFLAGS="$CFLAGS $GLIB_CFLAGS"
 LIBS="$GLIB_LIBS $LIBS -liscsi"
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <stdio.h>
-#include <iscsi/iscsi.h>
-
-int main(int argc, char *argv[])
-{
-	struct iscsi_context *iscsi;
-
-	iscsi = iscsi_create_context("iqn.2002-10.com.ronnie:client");
-	if (iscsi == NULL) {
-		printf("Failed to create iscsi context\n");
-		exit(10);
+	#include <stdlib.h>
+	#include <stdio.h>
+	#include <iscsi/iscsi.h>
+	
+	int main(int argc, char *argv[])
+	{
+		struct iscsi_context *iscsi;
+	
+		iscsi = iscsi_create_context("iqn.2002-10.com.ronnie:client");
+		if (iscsi == NULL) {
+			printf("Failed to create iscsi context\n");
+			exit(10);
+		}
+	
+		iscsi_destroy_context(iscsi);
+	
+		return 0;
 	}
-
-	iscsi_destroy_context(iscsi);
-
-	return 0;
-}
 ]])],[ac_cv_have_libiscsi=yes],[ac_cv_have_libiscsi=no],[echo $ac_n "compile with LIBISCSI. Assuming OK... $ac_c"
     ac_cv_have_libiscsi=no])
 CFLAGS="$ac_save_CFLAGS"
@@ -203,6 +256,7 @@ ac_save_LIBS="$LIBS"
 CFLAGS="$CFLAGS $GLIB_CFLAGS"
 LIBS="$GLIB_LIBS $LIBS -lnfs"
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdlib.h>
 #include <stdio.h>
 #include <sys/time.h>
 #include <nfsc/libnfs.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.72])
+AC_PREREQ([2.69])
 AC_INIT([dbench],[5.0],[ronniesahlberg@gmail.com])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([-Wall foreign subdir-objects])

--- a/dbench.h
+++ b/dbench.h
@@ -240,3 +240,8 @@ double timeval_elapsed(struct timeval *tv);
 double timeval_elapsed2(struct timeval *tv1, struct timeval *tv2);
 int write_sock(int s, char *buf, int size);
 char *get_next_arg(const char *args, int id);
+
+// copied from postgresql
+#if defined(HAVE_FDATASYNC) && !HAVE_DECL_FDATASYNC
+extern int  fdatasync(int fildes);
+#endif

--- a/system.c
+++ b/system.c
@@ -1,3 +1,4 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:t;  -*- */
 /* 
    dbench version 3
 
@@ -27,7 +28,9 @@
 
 ssize_t sys_getxattr(const char *path, const char *name, void *value, size_t size)
 {
-#if defined(HAVE_GETXATTR)
+#if defined(HAVE_GETXATTR_POS_FLAGS)
+	return getxattr(path, name, value, size, 0, 0);
+#elif defined(HAVE_GETXATTR)
 	return getxattr(path, name, value, size);
 #elif defined(HAVE_EXTATTR_GET_FILE)
 	char *s;
@@ -54,8 +57,10 @@ ssize_t sys_getxattr(const char *path, const char *name, void *value, size_t siz
 
 ssize_t sys_fgetxattr(int filedes, const char *name, void *value, size_t size)
 {
-#if defined(HAVE_FGETXATTR)
-	return fgetxattr(filedes, name, value, size);
+#if defined(HAVE_FGETXATTR_POS_FLAGS)
+  return fgetxattr(filedes, name, value, size, 0, 0);
+#elif defined(HAVE_FGETXATTR)
+  	return fgetxattr(filedes, name, value, size);
 #elif defined(HAVE_EXTATTR_GET_FD)
 	char *s;
 	int attrnamespace = (strncmp(name, "system", 6) == 0) ? 
@@ -87,8 +92,10 @@ ssize_t sys_fgetxattr(int filedes, const char *name, void *value, size_t size)
 
 int sys_fsetxattr(int filedes, const char *name, const void *value, size_t size, int flags)
 {
-#if defined(HAVE_FSETXATTR)
-	return fsetxattr(filedes, name, value, size, flags);
+#if defined(HAVE_FSETXATTR_POS)
+  return fsetxattr(filedes, name, value, size, 0, flags);
+#elif defined(HAVE_FSETXATTR)
+  return fsetxattr(filedes, name, value, size, flags);
 #elif defined(HAVE_EXTATTR_SET_FD)
 	char *s;
 	int retval = 0;


### PR DESCRIPTION
The get/set xattr functions under macOS always have a position and option flags. 

Added autoconf check to figure out which is present.

macOS does not support O_DIRECT flag to open, but can do similar by setting NO_CACHE on file descriptor with fcntl

For some reason the `fdatasync` is present on macOS but not declared in any public header, so a fix for this is added. Copied from a PostgreSQL thread. Apple recommends using fcntl(fd, F_FULLSYNC, 0). [1](https://www.postgresql.org/message-id/CA%2BhUKGLfe_ogA5VDi1Jxj_MPVJLcif8T_GuaW0aOs%2BpBZT033A%40mail.gmail.com)

Requirement for building on macOS: 
- homebrew with argp-standalone installed
- ./configure with CFLAGS and LDFLAGS including the argp-standalone include and library paths and LIBS="-largp"
- install libiscsi via homebrew and adjust above CFLAGS and LDFLAGS
